### PR TITLE
Change the version number to allow packages to use the same PPA

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-metee (4.1.0-0ubuntu1~ppa1) noble; urgency=medium
+metee (4.1.0-0ubuntu1~24.04~ppa1) noble; urgency=medium
 
   * Initial release.
 


### PR DESCRIPTION
This changes the format of the versions from `xxxx-0ubuntu1~ppa1` to `xxxx-0ubuntu1~24.04~ppa1 `so that the noble and oracular versions do not collide in the PPA.

The version is simply overwritten because the new version will technically be older than the old version ("p" > "2"), so we should start over at the beginning. Since this is only in our testing PPA so far, we don't need to worry about breaking anyone's updates.