### PR TITLE
Change the version number to allow packages to use the same PPA

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,19 +1,5 @@
-metee (4.1.0-0ubuntu1~ppa3) oracular; urgency=medium
-
-  * Fix dependencies.
-
- -- Pedro Kopper <pedro.kopper@canonical.com>  Wed, 14 Aug 2024 16:10:46 -0300
-
-metee (4.1.0-0ubuntu1~ppa2) oracular; urgency=medium
-
-  * Cleanup comments and extra directories.
-
- -- Pedro Kopper <pedro.kopper@canonical.com>  Wed, 14 Aug 2024 15:50:43 -0300
-
-metee (4.1.0-0ubuntu1~ppa1) oracular; urgency=medium
+metee (4.1.0-0ubuntu1~24.10~ppa1) oracular; urgency=medium
 
   * Initial release.
-  * Cleanup comments and extra directories.
-  * Fix dependencies.
 
- -- Pedro Kopper <pedro.kopper@canonical.com>  Wed, 14 Aug 2024 15:27:24 -0300
+ -- Shane McKee <shane.mckee@canonical.com>  Fri, 06 Sep 2024 18:58:36 +0800


### PR DESCRIPTION
This changes the format of the versions from `xxxx-0ubuntu1~ppa1` to `xxxx-0ubuntu1~24.10~ppa1` so that the noble and oracular versions do not collide in the PPA.

The version is simply overwritten because the new version will technically be older than the old version ("p" > "2"), so we should start over at the beginning. Since this is only in our testing PPA so far, we don't need to worry about breaking anyone's updates.